### PR TITLE
CORE-1805 - Added PR title check

### DIFF
--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: dylanvann/check-pull-request-title@v1
         with:
           # Match pull request titles in the form UI-1234 - Message.
-          pattern: '^((MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+'
+          pattern: '^((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -25,4 +25,4 @@ jobs:
           # MOBILE-123123 MOBILE-34534 - fix bug
           # hotfix/MOBILE-123123 - fix sueprbug
           # Revert MOBILE-123123 - revert because Lu didn't like it
-          pattern: '^((((hotfix\/|Revert\s|fix:\s|feat:\s|perf:\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'
+          pattern: '^((((hotfix\/|Revert\s|fix:\s|feat:\s|perf:\s|)(MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -15,5 +15,14 @@ jobs:
       - uses: actions/checkout@v1
       - uses: dylanvann/check-pull-request-title@v1
         with:
-          # Match pull request titles in the form UI-1234 - Message.
-          pattern: '^((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+'
+          # Match pull request titles in the form of:
+          # Release/s123 
+          # dev => canary
+          # canary => dev
+          # canary => master
+          # master => dev
+          # MOBILE-123123 - fix bug
+          # MOBILE-123123 MOBILE-34534 - fix bug
+          # hotfix/MOBILE-123123 - fix sueprbug
+          # Revert MOBILE-123123 - revert because Lu didn't like it
+          pattern: '^((((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -25,4 +25,4 @@ jobs:
           # MOBILE-123123 MOBILE-34534 - fix bug
           # hotfix/MOBILE-123123 - fix sueprbug
           # Revert MOBILE-123123 - revert because Lu didn't like it
-          pattern: '^((((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'
+          pattern: '^((((hotfix\/|Revert\s|fix:\s|feat:\s|perf:\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: dylanvann/check-pull-request-title@v1
         with:
           # Match pull request titles in the form UI-1234 - Message.
-          pattern: '^((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+'
+          pattern: '^((hotfix\/|Revert\s|)(MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -19,8 +19,11 @@ jobs:
           # Release/s123 
           # dev => canary
           # canary => dev
-          # canary => master
           # master => dev
+          # main => dev
+          # fix: MOBILE-123123 - fix bug
+          # feat: NYC-123123 - fix bug
+          # perf: MOBILE-123123 - fix bug
           # MOBILE-123123 - fix bug
           # MOBILE-123123 MOBILE-34534 - fix bug
           # hotfix/MOBILE-123123 - fix sueprbug

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -25,4 +25,4 @@ jobs:
           # MOBILE-123123 MOBILE-34534 - fix bug
           # hotfix/MOBILE-123123 - fix sueprbug
           # Revert MOBILE-123123 - revert because Lu didn't like it
-          pattern: '^((((hotfix\/|Revert\s|fix:\s|feat:\s|perf:\s|)(MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+)|Release\/s\d+|canary => dev|canary => master|master => dev|dev => canary)'
+          pattern: '^(((dev|canary|master|main)\s=>\sdev)|Release\/s\d+|(hotfix\/|Revert\s|fix:\s|feat:\s|perf:\s)?((MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+)'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           # Match pull request titles in the form of:
           # Release/s123 
-          # dev => canary
           # canary => dev
           # master => dev
           # main => dev

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -1,0 +1,19 @@
+name: 'PR name check'
+on:
+  pull_request:
+    types:
+      # Check title when opened.
+      - opened
+      # Check title when new commits are pushed.
+      # Required to use as a status check.
+      - synchronize
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dylanvann/check-pull-request-title@v1
+        with:
+          # Match pull request titles in the form UI-1234 - Message.
+          pattern: '^((MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE)-\d*\s)+-\s.+'

--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: dylanvann/check-pull-request-title@v1
         with:
           # Match pull request titles in the form UI-1234 - Message.
-          pattern: '^((MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE)-\d*\s)+-\s.+'
+          pattern: '^((MOBILE|IL|NYC|CLINICAL|CUSTOMER|CORE|DS)-\d*\s)+-\s.+'


### PR DESCRIPTION
# Reason for this
So the titles of the PRs can be checked automatically
Allowed:
```
fix: MOBILE-123123 - fix bug
feat: NYC-123123 - fix bug
perf: MOBILE-123123 - fix bug
Release/s123
canary => dev
master => dev
main => dev
MOBILE-123123 - fix bug
MOBILE-123123 MOBILE-34534 - fix bug
hotfix/MOBILE-123123 - fix sueprbug
Revert MOBILE-123123 - revert because Lu didn't like it```