### PR TITLE
CORE-1805 Modification so it doesn't force the -

### DIFF
--- a/workflow-templates/pr-name-check.yml
+++ b/workflow-templates/pr-name-check.yml
@@ -29,4 +29,5 @@ jobs:
           # hotfix/MOBILE-123123 - fix sueprbug
           # Revert "MOBILE-123123 - revert because Lu didn't like it"
           # Revert "perf: MOBILE-123123 - fix bug"
-          regex: '^(Revert\s\"?)?(((dev|canary|master|main)\s=>\sdev)|Release\/s\d+|(hotfix\/|fix:\s|feat:\s|perf:\s)?((MOBILE|IL|NYC|CORE|DS)-\d*\s)+-\s.+)'
+          regex: '^(Revert\s\"?)?(((dev|canary|master|main)\s=>\sdev)|Release\/s\d+|(hotfix\/|fix:\s|feat:\s|perf:\s)?((MOBILE|IL|NYC|CORE|DS)-\d*).+)'
+          


### PR DESCRIPTION
# Reason for this
It's kinda annoying that we need to have the dash after the ticket number so now it will accept:
`MOBILE-1234 Fixed this` instead of `MOBILE-1234 - Fixed this`
