### PR TITLE
CORE-9057 Add reusable workflow for merge conflict resolution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @yaeerm @nirtaltalk
+*       @yaeerm @nirtaltalk @jackm-ts

--- a/.github/workflows/resolve-merge-conflicts.yml
+++ b/.github/workflows/resolve-merge-conflicts.yml
@@ -1,0 +1,182 @@
+name: Resolve Merge Conflicts
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'The PR number of the conflicted merge-back PR'
+        required: true
+        type: number
+      head_branch:
+        description: 'Source branch of the merge-back PR (e.g., canary)'
+        required: true
+        type: string
+      base_branch:
+        description: 'Target branch of the merge-back PR (e.g., develop)'
+        required: true
+        type: string
+      label_name:
+        description: 'The label that triggered this workflow'
+        required: false
+        type: string
+        default: 'resolve-conflicts'
+      merge_back_title_pattern:
+        description: 'Regex pattern to validate merge-back PR titles'
+        required: false
+        type: string
+        default: '^(dev|canary|master|main) => dev$'
+
+jobs:
+  resolve-conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Validate merge-back PR
+        id: validate
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PATTERN: ${{ inputs.merge_back_title_pattern }}
+        run: |
+          if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
+            echo "::warning::PR title '$PR_TITLE' does not match merge-back pattern '$PATTERN'. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.validate.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GIT_TOKEN }}
+
+      - name: Configure git identity
+        if: steps.validate.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create resolution branch
+        if: steps.validate.outputs.skip == 'false'
+        id: create-branch
+        env:
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          BRANCH_NAME="resolve-conflicts/${HEAD_BRANCH}-to-${BASE_BRANCH}-${RUN_ID}"
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+
+          git checkout "origin/${HEAD_BRANCH}"
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      - name: Attempt merge
+        if: steps.validate.outputs.skip == 'false'
+        id: merge
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
+        run: |
+          git fetch origin "${BASE_BRANCH}"
+          if git merge "origin/${BASE_BRANCH}" --no-edit; then
+            echo "merge_clean=true" >> "$GITHUB_OUTPUT"
+            git push origin "${BRANCH_NAME}"
+          else
+            echo "merge_clean=false" >> "$GITHUB_OUTPUT"
+            git merge --abort
+          fi
+
+      - name: Create resolution PR
+        if: steps.validate.outputs.skip == 'false'
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
+          ORIGINAL_PR: ${{ inputs.pr_number }}
+          MERGE_CLEAN: ${{ steps.merge.outputs.merge_clean }}
+        run: |
+          if [ "$MERGE_CLEAN" == "true" ]; then
+            BODY=$(cat <<EOF
+          ## Auto-resolved merge conflicts
+
+          This PR was automatically created to resolve merge conflicts from the merge-back PR #${ORIGINAL_PR} (\`${HEAD_BRANCH} => ${BASE_BRANCH}\`).
+
+          The merge completed cleanly. **This PR is ready for review and merge.**
+
+          Once merged, the original PR #${ORIGINAL_PR} can be closed.
+          EOF
+          )
+          else
+            BODY=$(cat <<EOF
+          ## Merge conflict resolution needed
+
+          This PR was created to help resolve merge conflicts from the merge-back PR #${ORIGINAL_PR} (\`${HEAD_BRANCH} => ${BASE_BRANCH}\`).
+
+          ### How to resolve
+
+          1. Check out this branch locally:
+             \`\`\`
+             git fetch origin
+             git checkout ${BRANCH_NAME}
+             \`\`\`
+          2. Merge the target branch into it:
+             \`\`\`
+             git merge origin/${BASE_BRANCH}
+             \`\`\`
+          3. Resolve all conflicts
+          4. Commit and push:
+             \`\`\`
+             git add .
+             git commit
+             git push origin ${BRANCH_NAME}
+             \`\`\`
+
+          Once this PR is merged, the original PR #${ORIGINAL_PR} can be closed.
+          EOF
+          )
+          fi
+
+          PR_URL=$(gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${BRANCH_NAME}" \
+            --title "${HEAD_BRANCH} => ${BASE_BRANCH}" \
+            --body "${BODY}")
+
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on original PR
+        if: steps.validate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          MERGE_CLEAN: ${{ steps.merge.outputs.merge_clean }}
+          NEW_PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+          ORIGINAL_PR: ${{ inputs.pr_number }}
+        run: |
+          if [ "$MERGE_CLEAN" == "true" ]; then
+            COMMENT="A resolution PR has been created and the merge completed cleanly: ${NEW_PR_URL}
+
+          Once that PR is merged, this PR can be closed."
+          else
+            COMMENT="A resolution PR has been created: ${NEW_PR_URL}
+
+          Conflicts need manual resolution on that branch. See the PR description for instructions.
+          Once that PR is merged, this PR can be closed."
+          fi
+
+          gh pr comment "${ORIGINAL_PR}" --body "${COMMENT}"
+
+      - name: Remove trigger label
+        if: steps.validate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          ORIGINAL_PR: ${{ inputs.pr_number }}
+          LABEL_NAME: ${{ inputs.label_name }}
+        run: |
+          gh pr edit "${ORIGINAL_PR}" --remove-label "${LABEL_NAME}"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # .github
+
+Shared GitHub Actions workflows and configurations for the organization.
+
+## Workflows
+
+### Resolve Merge Conflicts (`resolve-merge-conflicts.yml`)
+
+Automates the creation of a conflict-resolution branch and PR when merge-back PRs (e.g., `canary => dev`) have conflicts.
+
+**How it works:**
+1. Add the `resolve-conflicts` label to a conflicted merge-back PR
+2. The workflow creates a new branch from the source branch (e.g., `canary`)
+3. It attempts to merge the target branch (e.g., `develop`) into it
+4. A new PR is opened targeting the base branch, with instructions for manual resolution if needed
+5. The original PR is commented with a link to the resolution PR
+
+**Caller workflow** — add this to each repo that needs it:
+
+```yaml
+name: Resolve Merge Conflicts
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  resolve-conflicts:
+    if: github.event.label.name == 'resolve-conflicts'
+    uses: talktala/lahore/.github/workflows/resolve-merge-conflicts.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      head_branch: ${{ github.event.pull_request.head.ref }}
+      base_branch: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit
+```
+
+**Required secrets:** `GIT_TOKEN` (PAT with repo access)
+
+### PR Name Check (`pr-name-check.yml`)
+
+Validates PR titles match the organization's naming conventions.
+
+### JIRA Label (`jira-label.yml`)
+
+Auto-labels JIRA tickets when PRs are merged to protected branches.
+
+### MIME Environment (`mime-environment.yml`)
+
+Creates/updates Qovery environments for MIME epic branches.
+
+### MIME Environment Cleanup (`mime-environment-cleanup.yml`)
+
+Cleans up Qovery environments when MIME branches are deleted.


### PR DESCRIPTION
# JIRA ticket
<!-- TODO: add ticket number once created -->

# Optional context for reviewers

Adds a reusable GitHub Actions workflow (`resolve-merge-conflicts.yml`) that automates the conflict resolution process for merge-back PRs (e.g., `canary => dev`). When a `resolve-conflicts` label is added to a conflicted PR, the workflow creates a new branch from the source branch, attempts to merge the target branch into it, and opens a resolution PR with instructions for manual conflict resolution if needed.

Also updates the README with documentation for all shared workflows and a caller workflow template for consuming repos.

## Type of change
- [ ] Bug fix
- [ ] Story (Feature)
- [x] Task